### PR TITLE
trigger major version release

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
+// BREAKING CHANGE test: bump to next major version
 export default {};


### PR DESCRIPTION
Intentional breaking change to verify that the conventional-commits changelog GitHub Action publishes a new **major** version (4.0.3 → 5.0.0).

- Commit uses `feat!:` with a `BREAKING CHANGE:` footer.
- Once merged into `main`, the release action should bump to a new major version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)